### PR TITLE
VIMC-3103: Generalise token passing for orderly web api client

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support For 'OrderlyWeb'
-Version: 0.1.0
+Version: 0.1.1
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -66,12 +66,10 @@ R6_orderlyweb_api_client <- R6::R6Class(
       self$url <- orderlyweb_api_client_url(hostname, port, https, prefix,
                                             api_version)
       self$name <- orderlyweb_api_client_name(name, hostname, port, prefix)
-      if (!is.null(token)) {
-        if (!is.function(token)) {
-          token <- orderlyweb_token_constant(token)
-        }
-        self$token <- token
+      if (!is.function(token)) {
+        token <- orderlyweb_token_constant(token)
       }
+      self$token <- token
       self$options <- orderlyweb_api_client_options(insecure, verbose)
     },
 

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -137,9 +137,9 @@ orderlyweb_api_client_name <- function(name, hostname, port, prefix) {
     return(name)
   }
   if (is.null(prefix)) {
-    sprintf("%s:%s", hostname, port)
+    sprintf("%s:%d", hostname, port)
   } else {
-    sprintf("%s:%s/%s", hostname, port, prefix)
+    sprintf("%s:%d/%s", hostname, port, prefix)
   }
 }
 

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -2,7 +2,7 @@
 ##'
 ##' @title Create a low-level OrderlyWeb client
 ##'
-##' @param hostname Fully qualified hostname for the OrderlyWeb instance
+##' @param host Fully qualified hostname for the OrderlyWeb instance
 ##'
 ##' @param port Port to use
 ##'
@@ -16,7 +16,7 @@
 ##' @param name A friendly name for the server (e.g, "production" or
 ##'   "testing") which may be printed when using the remote, or when
 ##'   authenticating.  If not provided then a name will be constructed
-##'   from \code{hostname}, \code{port} and (if provided)
+##'   from \code{host}, \code{port} and (if provided)
 ##'   \code{prefix}.
 ##'
 ##' @param https Optional logical, indicating if this is an https
@@ -40,10 +40,10 @@
 ##' cl <- orderlyweb::orderlyweb_api_client(host = "example.com", port = 443,
 ##'                                         token = "mytoken")
 ##' cl$is_authorised()
-orderlyweb_api_client <- function(hostname, port, token, name = NULL,
+orderlyweb_api_client <- function(host, port, token, name = NULL,
                                   https = TRUE, prefix = NULL, api_version = 1,
                                   insecure = FALSE, verbose = FALSE) {
-  R6_orderlyweb_api_client$new(hostname, port, token, name = name,
+  R6_orderlyweb_api_client$new(host, port, token, name = name,
                                https = https, prefix = prefix,
                                api_version = api_version, insecure = insecure,
                                verbose = verbose)
@@ -61,11 +61,11 @@ R6_orderlyweb_api_client <- R6::R6Class(
     token = NULL,
     api_token = NULL,
 
-    initialize = function(hostname, port, token, name, https, prefix,
+    initialize = function(host, port, token, name, https, prefix,
                           api_version, insecure, verbose) {
-      self$url <- orderlyweb_api_client_url(hostname, port, https, prefix,
+      self$url <- orderlyweb_api_client_url(host, port, https, prefix,
                                             api_version)
-      self$name <- orderlyweb_api_client_name(name, hostname, port, prefix)
+      self$name <- orderlyweb_api_client_name(name, host, port, prefix)
       if (!is.function(token)) {
         token <- orderlyweb_token_constant(token)
       }
@@ -129,15 +129,15 @@ orderlyweb_api_client_login <- function(url, token, options) {
 }
 
 
-orderlyweb_api_client_name <- function(name, hostname, port, prefix) {
+orderlyweb_api_client_name <- function(name, host, port, prefix) {
   if (!is.null(name)) {
     assert_scalar_character(name)
     return(name)
   }
   if (is.null(prefix)) {
-    sprintf("%s:%d", hostname, port)
+    sprintf("%s:%d", host, port)
   } else {
-    sprintf("%s:%d/%s", hostname, port, prefix)
+    sprintf("%s:%d/%s", host, port, prefix)
   }
 }
 
@@ -148,10 +148,10 @@ orderlyweb_api_client_name <- function(name, hostname, port, prefix) {
 ##   https://ebola2018.dide.ic.ac.uk/api/v1/
 ##   https://support.montagu.dide.ic.ac.uk:10443/reports/api/v1/
 ##
-## <protocol>://<hostname>:<port><prefix>/api/v1
-orderlyweb_api_client_url <- function(hostname, port, https, prefix,
+## <protocol>://<host>:<port><prefix>/api/v1
+orderlyweb_api_client_url <- function(host, port, https, prefix,
                                       api_version) {
-  assert_scalar_character(hostname)
+  assert_scalar_character(host)
   assert_scalar_integer(port)
   assert_scalar_logical(https)
   assert_scalar_integer(api_version)
@@ -168,7 +168,7 @@ orderlyweb_api_client_url <- function(hostname, port, https, prefix,
     }
   }
 
-  url_www <- sprintf("%s://%s:%d%s", protocol, hostname, port, prefix)
+  url_www <- sprintf("%s://%s:%d%s", protocol, host, port, prefix)
   list(www = url_www,
        api = sprintf("%s/api/v%d", url_www, api_version))
 }

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -85,7 +85,7 @@ R6_orderlyweb_api_client <- R6::R6Class(
         if (is.function(self$token)) {
           token <- self$token()
         } else {
-          token <- token
+          token <- self$token
         }
         self$api_token <-
           orderlyweb_api_client_login(self$url$api, token, self$options)

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -68,7 +68,7 @@ R6_orderlyweb_api_client <- R6::R6Class(
       self$name <- orderlyweb_api_client_name(name, hostname, port, prefix)
       if (!is.null(token)) {
         if (!is.function(token)) {
-          assert_scalar_character(token)
+          token <- orderlyweb_token_constant(token)
         }
         self$token <- token
       }
@@ -82,13 +82,8 @@ R6_orderlyweb_api_client <- R6::R6Class(
     authorise = function(refresh = FALSE) {
       if (refresh || is.null(self$api_token)) {
         message(sprintf("Authorising with server '%s'", self$name))
-        if (is.function(self$token)) {
-          token <- self$token()
-        } else {
-          token <- self$token
-        }
         self$api_token <-
-          orderlyweb_api_client_login(self$url$api, token, self$options)
+          orderlyweb_api_client_login(self$url$api, self$token(), self$options)
       }
     },
 
@@ -245,4 +240,12 @@ orderlyweb_accept <- function(accept) {
          zip = httr::accept("application/zip"),
          csv = httr::accept("text/csv"),
          stop("unknown type ", accept))
+}
+
+
+orderlyweb_token_constant <- function(token) {
+  assert_scalar_character(token)
+  function() {
+    token
+  }
 }

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -7,9 +7,9 @@
 ##' @examples
 ##' remote <- orderlyweb::orderlyweb_remote("example.com", 443, "mytoken")
 ##' remote
-orderlyweb_remote <- function(hostname, port, token, https = TRUE,
+orderlyweb_remote <- function(host, port, token, https = TRUE,
                               prefix = NULL, name = NULL) {
-  R6_orderlyweb_remote$new(hostname, port, token, https, prefix, name)
+  R6_orderlyweb_remote$new(host, port, token, https, prefix, name)
 }
 
 
@@ -22,8 +22,8 @@ R6_orderlyweb_remote <- R6::R6Class(
   ),
 
   public = list(
-    initialize = function(hostname, port, token, https, prefix, name) {
-      private$client <- orderlyweb(hostname = hostname, port = port,
+    initialize = function(host, port, token, https, prefix, name) {
+      private$client <- orderlyweb(host = host, port = port,
                                    token = token, https = https,
                                    prefix = prefix, name = name)
     },

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -8,8 +8,8 @@
 ##' remote <- orderlyweb::orderlyweb_remote("example.com", 443, "mytoken")
 ##' remote
 orderlyweb_remote <- function(hostname, port, token, https = TRUE,
-                              prefix = NULL) {
-  R6_orderlyweb_remote$new(hostname, port, token, https, prefix)
+                              prefix = NULL, name = NULL) {
+  R6_orderlyweb_remote$new(hostname, port, token, https, prefix, name)
 }
 
 
@@ -22,10 +22,10 @@ R6_orderlyweb_remote <- R6::R6Class(
   ),
 
   public = list(
-    initialize = function(hostname, port, token, https, prefix) {
-      private$client <- orderlyweb(hostname = hostname , port = port,
+    initialize = function(hostname, port, token, https, prefix, name) {
+      private$client <- orderlyweb(hostname = hostname, port = port,
                                    token = token, https = https,
-                                   prefix = prefix)
+                                   prefix = prefix, name = name)
     },
 
     list_reports = function() {

--- a/man/orderlyweb_api_client.Rd
+++ b/man/orderlyweb_api_client.Rd
@@ -4,7 +4,7 @@
 \alias{orderlyweb_api_client}
 \title{Create a low-level OrderlyWeb client}
 \usage{
-orderlyweb_api_client(hostname, port, token, https = TRUE,
+orderlyweb_api_client(hostname, port, token, name = NULL, https = TRUE,
   prefix = NULL, api_version = 1, insecure = FALSE,
   verbose = FALSE)
 }
@@ -14,6 +14,12 @@ orderlyweb_api_client(hostname, port, token, https = TRUE,
 \item{port}{Port to use}
 
 \item{token}{Your application token for authentication}
+
+\item{name}{A friendly name for the server (e.g, "production" or
+"testing") which may be printed when using the remote, or when
+authenticating.  If not provided then a name will be constructed
+from \code{hostname}, \code{port} and (if provided)
+\code{prefix}.}
 
 \item{https}{Optional logical, indicating if this is an https
 connection - this should be \code{TRUE} in all production

--- a/man/orderlyweb_api_client.Rd
+++ b/man/orderlyweb_api_client.Rd
@@ -4,12 +4,12 @@
 \alias{orderlyweb_api_client}
 \title{Create a low-level OrderlyWeb client}
 \usage{
-orderlyweb_api_client(hostname, port, token, name = NULL, https = TRUE,
+orderlyweb_api_client(host, port, token, name = NULL, https = TRUE,
   prefix = NULL, api_version = 1, insecure = FALSE,
   verbose = FALSE)
 }
 \arguments{
-\item{hostname}{Fully qualified hostname for the OrderlyWeb instance}
+\item{host}{Fully qualified hostname for the OrderlyWeb instance}
 
 \item{port}{Port to use}
 
@@ -23,7 +23,7 @@ token.}
 \item{name}{A friendly name for the server (e.g, "production" or
 "testing") which may be printed when using the remote, or when
 authenticating.  If not provided then a name will be constructed
-from \code{hostname}, \code{port} and (if provided)
+from \code{host}, \code{port} and (if provided)
 \code{prefix}.}
 
 \item{https}{Optional logical, indicating if this is an https

--- a/man/orderlyweb_api_client.Rd
+++ b/man/orderlyweb_api_client.Rd
@@ -13,7 +13,12 @@ orderlyweb_api_client(hostname, port, token, name = NULL, https = TRUE,
 
 \item{port}{Port to use}
 
-\item{token}{Your application token for authentication}
+\item{token}{Your application token for authentication.  The
+appropriate value here will depend on the authentication support
+that is built into the OrderlyWeb server that you are
+communicating with.  Provide the token directly (as a string) or
+provide a callback function that takes no arguments and returns
+token.}
 
 \item{name}{A friendly name for the server (e.g, "production" or
 "testing") which may be printed when using the remote, or when

--- a/man/orderlyweb_remote.Rd
+++ b/man/orderlyweb_remote.Rd
@@ -4,11 +4,11 @@
 \alias{orderlyweb_remote}
 \title{Create orderly remote}
 \usage{
-orderlyweb_remote(hostname, port, token, https = TRUE, prefix = NULL,
+orderlyweb_remote(host, port, token, https = TRUE, prefix = NULL,
   name = NULL)
 }
 \arguments{
-\item{hostname}{Fully qualified hostname for the OrderlyWeb instance}
+\item{host}{Fully qualified hostname for the OrderlyWeb instance}
 
 \item{port}{Port to use}
 
@@ -29,7 +29,7 @@ path within some larger website.}
 \item{name}{A friendly name for the server (e.g, "production" or
 "testing") which may be printed when using the remote, or when
 authenticating.  If not provided then a name will be constructed
-from \code{hostname}, \code{port} and (if provided)
+from \code{host}, \code{port} and (if provided)
 \code{prefix}.}
 }
 \description{

--- a/man/orderlyweb_remote.Rd
+++ b/man/orderlyweb_remote.Rd
@@ -4,14 +4,20 @@
 \alias{orderlyweb_remote}
 \title{Create orderly remote}
 \usage{
-orderlyweb_remote(hostname, port, token, https = TRUE, prefix = NULL)
+orderlyweb_remote(hostname, port, token, https = TRUE, prefix = NULL,
+  name = NULL)
 }
 \arguments{
 \item{hostname}{Fully qualified hostname for the OrderlyWeb instance}
 
 \item{port}{Port to use}
 
-\item{token}{Your application token for authentication}
+\item{token}{Your application token for authentication.  The
+appropriate value here will depend on the authentication support
+that is built into the OrderlyWeb server that you are
+communicating with.  Provide the token directly (as a string) or
+provide a callback function that takes no arguments and returns
+token.}
 
 \item{https}{Optional logical, indicating if this is an https
 connection - this should be \code{TRUE} in all production
@@ -19,6 +25,12 @@ settings or credentials will be sent in the clear!}
 
 \item{prefix}{A prefix, if your OrderlyWeb server is mounted at a
 path within some larger website.}
+
+\item{name}{A friendly name for the server (e.g, "production" or
+"testing") which may be printed when using the remote, or when
+authenticating.  If not provided then a name will be constructed
+from \code{hostname}, \code{port} and (if provided)
+\code{prefix}.}
 }
 \description{
 Implements an orderly "remote" using OrderlyWeb as a backend.  Use

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -13,7 +13,7 @@ test_that("Authentication logic", {
                                       paste("Bearer", "aninvalidtoken"))
   expect_message(
     res2 <- cl$GET("/reports/"),
-    "Authorising with server http://localhost:8888")
+    "Authorising with server 'localhost:8888'")
   expect_equal(res1, res2)
 })
 

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -76,3 +76,16 @@ test_that("download type switching", {
   expect_error(orderlyweb_accept("xlsx"),
                "unknown type xlsx")
 })
+
+
+test_that("name validation builds a name", {
+  expect_equal(
+    orderlyweb_api_client_name("given", "host", 443, "prefix"),
+    "given")
+  expect_equal(
+    orderlyweb_api_client_name(NULL, "host", 443, NULL),
+    "host:443")
+  expect_equal(
+    orderlyweb_api_client_name(NULL, "host", 443, "prefix"),
+    "host:443/prefix")
+})

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -18,6 +18,25 @@ test_that("Authentication logic", {
 })
 
 
+test_that("Authenticate with function", {
+  skip_if_no_orderlyweb_server()
+  host <- "localhost"
+  port <- 8888
+  token <- function() {
+    message("<<custom token function>>")
+    Sys.getenv("ORDERLYWEB_TEST_TOKEN")
+  }
+  https <- FALSE
+  cl <- orderlyweb_api_client(host, port, token, https = FALSE)
+
+  expect_false(cl$is_authorised())
+  expect_message(
+    res <- cl$GET("/"),
+    "<<custom token function>>", fixed = TRUE)
+  expect_true(cl$is_authorised())
+})
+
+
 test_that("API client must use absolute paths", {
   cl <- test_orderlyweb_api_client()
   expect_error(cl$GET("reports"),


### PR DESCRIPTION
This PR adds support for a slightly more general approach to getting a token for authentication with orderlyweb/OrderlyWeb:

* instead of a string providing a function, the user may provide a function that will return a string
* this fits in with the lazy authentication approach we use elsewhere and the function will only be called at the point that authentication happens (not when the client is created)

Other changes that roll into this

* There is a change here too to accept a `name` argument; this is for consistency with montagu and will be used in the the montagu-r PR https://github.com/vimc/montagu-r/pull/37
* Previously token processing was done only when not NULL, but there was no logic to handle what happened if it was NULL.  This branch has been removed.

This is perhaps overkill for us, as we have only two methods of getting a token (github and montagu) but it feels like a general solution and should be pretty flexible going forward.
