### PR TITLE
VIMC-2953: orderly takes responsibility for copying directory in pull_archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ services:
 r_packages:
   - covr
 r_github_packages:
-  # TODO: remove the branch before merge
-  - vimc/orderly@vimc-2953
+  - vimc/orderly
 after_success:
   - Rscript -e 'covr::codecov()'
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 r_packages:
   - covr
 r_github_packages:
-  - vimc/orderly
+  - vimc/orderly@vimc-2953
 after_success:
   - Rscript -e 'covr::codecov()'
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 r_packages:
   - covr
 r_github_packages:
+  # TODO: remove the branch before merge
   - vimc/orderly@vimc-2953
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Imports:
     R6,
     httr,
     jsonlite,
-    orderly,
+    orderly (>= 0.7.11),
     progress
 Suggests:
     mockery,

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -37,8 +37,9 @@ R6_orderlyweb_remote <- R6::R6Class(
     },
 
     pull = function(name, id, root, progress = TRUE) {
-      dest <- private$client$report_download(name, id, progress = progress)
-      orderly:::unzip_archive(dest, root, name, id)
+      zip <- private$client$report_download(name, id, progress = progress)
+      on.exit(unlink(zip))
+      unzip_archive(zip, name, id)
     },
 
     run = function(name, parameters = NULL, ref = NULL, timeout = NULL,

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -36,7 +36,7 @@ R6_orderlyweb_remote <- R6::R6Class(
       private$client$report_versions(name)
     },
 
-    pull = function(name, id, root, progress = TRUE) {
+    pull = function(name, id, progress = TRUE) {
       zip <- private$client$report_download(name, id, progress = progress)
       on.exit(unlink(zip))
       unzip_archive(zip, name, id)

--- a/R/tools.R
+++ b/R/tools.R
@@ -1,0 +1,24 @@
+unzip_archive <- function(zip, name, id) {
+  dest <- tempfile()
+  res <- utils::unzip(zip, exdir = dest)
+
+  files <- dir(dest, all.files = TRUE, no.. = TRUE)
+  if (length(files) == 0L) {
+    stop("Corrupt zip file? No files extracted")
+  } else if (length(files) > 1L) {
+    stop("Invalid orderly archive", call. = FALSE)
+  }
+  if (files != id) {
+    stop(sprintf("This is archive '%s' but expected '%s'",
+                 files, id), call. = FALSE)
+  }
+
+  expected <- c("orderly.yml", "orderly_run.rds")
+  msg <- !file.exists(file.path(dest, id, expected))
+  if (any(msg)) {
+    stop(sprintf("Invalid orderly archive: missing files %s",
+                 paste(expected[msg], collapse = ", ")), call. = FALSE)
+  }
+
+  file.path(dest, id)
+}

--- a/tests/testthat/helper-orderlyweb.R
+++ b/tests/testthat/helper-orderlyweb.R
@@ -50,3 +50,10 @@ zip_dir <- function(path, dest = paste0(basename(path), ".zip")) {
   }
   normalizePath(dest)
 }
+
+
+with_dir <- function(path, expr) {
+  owd <- setwd(path)
+  on.exit(setwd(owd))
+  force(expr)
+}

--- a/tests/testthat/helper-orderlyweb.R
+++ b/tests/testthat/helper-orderlyweb.R
@@ -39,3 +39,14 @@ test_orderlyweb_api_client <- function(use_cache = TRUE) {
 test_orderlyweb <- function(use_cache = TRUE) {
   orderlyweb(api_client = test_orderlyweb_api_client(use_cache))
 }
+
+
+zip_dir <- function(path, dest = paste0(basename(path), ".zip")) {
+  owd <- setwd(dirname(path))
+  on.exit(setwd(owd))
+  code <- utils::zip(dest, basename(path), extras = "-q")
+  if (code != 0) {
+    stop("error running zip")
+  }
+  normalizePath(dest)
+}

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -61,7 +61,14 @@ test_that("pull", {
                               token = token, https = FALSE)
   dest <- orderly::orderly_example("demo")
   v <- max(remote$list_versions("minimal"))
-  remote$pull("minimal", v, dest, FALSE)
+
+  ## Directly pull and see the report:
+  path <- remote$pull("minimal", v, FALSE)
+  expect_true("orderly_run.rds" %in% dir(path))
+  expect_equal(nrow(orderly::orderly_list_archive(root = dest)), 0)
+
+  ## Pull into the archive
+  orderly::orderly_pull_archive("minimal", v, dest, remote = remote)
   res <- orderly::orderly_list_archive(root = dest)
   expect_equal(res, data_frame(name = "minimal", id = v))
 })

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -35,7 +35,7 @@ test_that("unpack failure: not an orderly archive", {
   dir.create(tmp, FALSE, TRUE)
   file.create(file.path(tmp, c("a", "b")))
   zip <- tempfile(fileext = ".zip")
-  withr::with_dir(tmp, zip(zip, dir(), extras = "-q"))
+  with_dir(tmp, zip(zip, dir(), extras = "-q"))
   expect_error(unzip_archive(zip, NULL, NULL),
                "Invalid orderly archive")
 })

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -1,0 +1,67 @@
+context("tools")
+
+test_that("unpack archive", {
+  testthat::skip_on_cran()
+  path <- orderly::orderly_example("minimal")
+  id <- orderly::orderly_run("example", root = path, echo = FALSE)
+  p <- orderly::orderly_commit(id, root = path)
+
+  zip <- zip_dir(p)
+
+  path <- unzip_archive(zip, "example", id)
+  expect_equal(basename(path), id)
+  expect_equal(sort(dir(file.path(path), recursive = TRUE)),
+               sort(dir(p, recursive = TRUE)))
+})
+
+
+test_that("unpack report failure: corrupt download", {
+  testthat::skip_on_cran()
+  bytes <- as.raw(c(0x50, 0x4b, 0x05, 0x06, rep(0x00, 18L)))
+  zip <- tempfile()
+  writeBin(bytes, zip)
+  ## This test might be platform dependent as a sane unzip function
+  ## would have caught this.
+  expect_error(suppressWarnings(
+    unzip_archive(zip, NULL, NULL)),
+    "Corrupt zip file? No files extracted",
+    fixed = TRUE)
+})
+
+
+test_that("unpack failure: not an orderly archive", {
+  testthat::skip_on_cran()
+  tmp <- file.path(tempfile(), "parent")
+  dir.create(tmp, FALSE, TRUE)
+  file.create(file.path(tmp, c("a", "b")))
+  zip <- tempfile(fileext = ".zip")
+  withr::with_dir(tmp, zip(zip, dir(), extras = "-q"))
+  expect_error(unzip_archive(zip, NULL, NULL),
+               "Invalid orderly archive")
+})
+
+
+test_that("unpack failure: not expected id", {
+  testthat::skip_on_cran()
+  id <- orderly:::new_report_id()
+  tmp <- file.path(tempfile(), id)
+  dir.create(tmp, FALSE, TRUE)
+  dir.create(file.path(tmp, "orderly.yml"))
+  zip <- zip_dir(tmp)
+  expect_error(unzip_archive(zip, NULL, "other"),
+               sprintf("This is archive '%s' but expected 'other'", id),
+               fixed = TRUE)
+})
+
+
+test_that("unpack failure: missing files", {
+  testthat::skip_on_cran()
+  id <- orderly:::new_report_id()
+  tmp <- file.path(tempfile(), id)
+  dir.create(tmp, FALSE, TRUE)
+  dir.create(file.path(tmp, "orderly.yml"))
+  zip <- zip_dir(tmp)
+  expect_error(unzip_archive(zip, NULL, id),
+               "Invalid orderly archive: missing files orderly_run.rds",
+               fixed = TRUE)
+})


### PR DESCRIPTION
This is the orderlyweb half of https://github.com/vimc/orderly/pull/119

Most of the new code here was moved from orderly, along with the test

Note the the `.travis.yml` change should be reverted before merge