### PR TITLE
VIMC-3168: Add support for returning report url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support For 'OrderlyWeb'
-Version: 0.1.1
+Version: 0.1.2
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# orderlyweb 0.1.2
+
+* `orderlyweb_remote` now implements `url_report`, as expected by `orderly` >= 0.8.2 (VIMC-2421)

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -42,6 +42,10 @@ R6_orderlyweb_remote <- R6::R6Class(
       unzip_archive(zip, name, id)
     },
 
+    url_report = function(name, id) {
+      sprintf("%s/%s/%s/", private$client$api_client$url$www, name, id)
+    },
+
     run = function(name, parameters = NULL, ref = NULL, timeout = NULL,
                    wait = 1000, poll = 1, progress = TRUE,
                    stop_on_error = TRUE, open = FALSE) {

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -82,3 +82,19 @@ test_that("run", {
   res <- remote$run("minimal", open = FALSE, progress = FALSE)
   expect_equal(max(remote$list_versions("minimal")), res$id)
 })
+
+
+test_that("url_report returns expected url", {
+  cl <- orderlyweb_remote("host", 8888, "token")
+  expect_equal(
+    cl$url_report("myreport", "20191007-160636-c822cacd"),
+    "https://host:8888/myreport/20191007-160636-c822cacd/")
+})
+
+
+test_that("url_report includes prefix", {
+  cl <- orderlyweb_remote("host", 8888, "token", prefix = "prefix")
+  expect_equal(
+    cl$url_report("name", "id"),
+    "https://host:8888/prefix/name/id/")
+})


### PR DESCRIPTION
This PR adds support for querying for the canonical location of a report. The corresponding orderly PR (VIMC-3105) will depend on this behaviour in order to create the slack message. This is (I believe) the last bit of knowledge about the orderly server/montagu implementation that needed removing from orderly

