### PR TITLE
VIMC-3138: Add stop_on_timeout support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support For 'OrderlyWeb'
-Version: 0.1.2
+Version: 0.1.3
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderlyweb 0.1.3
+
+* The ability to run reports has been restored (VIMC-3138)
+
 # orderlyweb 0.1.2
 
 * `orderlyweb_remote` now implements `url_report`, as expected by `orderly` >= 0.8.2 (VIMC-2421)

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -48,11 +48,12 @@ R6_orderlyweb_remote <- R6::R6Class(
 
     run = function(name, parameters = NULL, ref = NULL, timeout = NULL,
                    wait = 1000, poll = 1, progress = TRUE,
-                   stop_on_error = TRUE, open = FALSE) {
+                   stop_on_error = TRUE, stop_on_timeout = TRUE, open = FALSE) {
       private$client$report_run(name = name, parameters = parameters,
                                 ref = ref, timeout = timeout, wait = wait,
                                 poll = poll, open = open,
                                 stop_on_error = stop_on_error,
+                                stop_on_timeout = stop_on_timeout,
                                 progress = progress)
     }
   ))

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -131,7 +131,8 @@ R6_orderlyweb <- R6::R6Class(
     report_run = function(name, parameters = NULL, ref = NULL,
                           update = TRUE, timeout = NULL, wait = Inf,
                           poll = 0.5, open = FALSE,
-                          stop_on_error = FALSE, progress = TRUE) {
+                          stop_on_error = FALSE, stop_on_timeout = TRUE,
+                          progress = TRUE) {
       if (!is.null(parameters)) {
         stop("parameters not yet supported")
       }
@@ -143,6 +144,7 @@ R6_orderlyweb <- R6::R6Class(
       if (wait > 0) {
         self$report_run_wait(res, timeout = wait, poll = poll, open = open,
                              stop_on_error = stop_on_error,
+                             stop_on_timeout = stop_on_timeout,
                              progress = progress)
       } else {
         res
@@ -160,6 +162,7 @@ R6_orderlyweb <- R6::R6Class(
 
     report_run_wait = function(x, timeout = Inf, poll = 0.5,
                                open = FALSE, stop_on_error = FALSE,
+                               stop_on_timeout = TRUE,
                                progress = TRUE, output = TRUE) {
       if (!inherits(x, "orderlyweb_run")) {
         stop("Expected an 'orderlyweb_run' object")
@@ -167,6 +170,7 @@ R6_orderlyweb <- R6::R6Class(
       report_run_wait(x$path, x$name, x$key, self,
                       timeout = timeout, poll = poll, open = open,
                       stop_on_error = stop_on_error,
+                      stop_on_timeout = stop_on_timeout,
                       progress = progress)
     },
 

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -1,5 +1,5 @@
 report_run_wait <- function(path, name, key, client, timeout, poll, open,
-                            progress, stop_on_error) {
+                            progress, stop_on_error, stop_on_timeout) {
   if (progress) {
     message(sprintf("running report '%s' as '%s'", name, key))
   }
@@ -19,7 +19,11 @@ report_run_wait <- function(path, name, key, client, timeout, poll, open,
     }
 
     if (Sys.time() > t_stop) {
-      stop("timeout reached")
+      if (stop_on_timeout) {
+        stop("timeout reached")
+      } else {
+        break
+      }
     }
 
     Sys.sleep(if (ans$status == "queued") max(poll, 1) else poll)

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -308,4 +308,19 @@ test_that("timeout", {
   expect_error(
     cl$report_run_wait(ans, timeout = 0, poll = 0, progress = FALSE),
     "timeout reached")
+  expect_error(
+    cl$report_run_wait(ans, timeout = 10, poll = 1, progress = FALSE),
+    NA)
+})
+
+
+test_that("timeout without error", {
+  cl <- test_orderlyweb()
+  ans <- cl$report_run("slow10", wait = FALSE)
+  res <- cl$report_run_wait(ans, timeout = 2, poll = 0, progress = FALSE,
+                            stop_on_timeout = FALSE)
+  expect_equal(res$status, "running")
+  res <- cl$report_run_wait(ans, timeout = 10, poll = 0, progress = FALSE,
+                            stop_on_timeout = FALSE)
+  expect_equal(res$status, "success")
 })


### PR DESCRIPTION
This PR adds support for `stop_on_timeout`, as passed from `orderly`, along with a minimal test