### PR TITLE
vimc-3376: fix URL in run report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support For 'OrderlyWeb'
-Version: 0.1.3
+Version: 0.1.4
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -127,7 +127,7 @@ report_wait_cleanup <- function(name, ans, progress, stop_on_error,
   }
 
   if (ans$status == "success") {
-    url <- sprintf("%s/reports/%s/%s", client$api_client$url$www,
+    url <- sprintf("%s/report/%s/%s", client$api_client$url$www,
                    name, ans$version)
     if (open) {
       message("Opening report in browser (you may need to log in)")

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -254,7 +254,7 @@ test_that("run: simple", {
   expect_equal(res$status, "success")
   expect_setequal(names(res$output), c("stderr", "stdout"))
   expect_equal(res$url,
-               paste0("http://localhost:8888/reports/minimal/", res$id))
+               paste0("http://localhost:8888/report/minimal/", res$id))
   expect_match(res$output$stderr, "[ name       ]  minimal",
                fixed = TRUE, all = FALSE)
 })
@@ -269,7 +269,7 @@ test_that("run: simple", {
   expect_equal(res$status, "success")
   expect_setequal(names(res$output), c("stderr", "stdout"))
   expect_equal(res$url,
-               paste0("http://localhost:8888/reports/minimal/", res$id))
+               paste0("http://localhost:8888/report/minimal/", res$id))
   expect_match(res$output$stderr, "[ name       ]  minimal",
                fixed = TRUE, all = FALSE)
 })

--- a/tests/testthat/test-report-run.R
+++ b/tests/testthat/test-report-run.R
@@ -108,7 +108,7 @@ test_that("cleanup - open url", {
   m <- mockery::mock()
   mockery::stub(report_wait_cleanup, "utils::browseURL", m)
   res1 <- report_wait_cleanup("name", ans, FALSE, TRUE, FALSE, client)
-  expect_equal(res1$url, "https://example.com/reports/reports/name/id")
+  expect_equal(res1$url, "https://example.com/reports/report/name/id")
   mockery::expect_called(m, 0)
 
   res2 <- report_wait_cleanup("name", ans, FALSE, TRUE, TRUE, client)


### PR DESCRIPTION
Before merging, verify that this works on both ebola/ncov and montagu as these are the two setup types.