### PR TITLE
vimc-3787: provide a friendly name for the remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support For 'OrderlyWeb'
-Version: 0.1.6
+Version: 0.1.7
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -22,10 +22,13 @@ R6_orderlyweb_remote <- R6::R6Class(
   ),
 
   public = list(
+    name = NULL,
+
     initialize = function(host, port, token, https, prefix, name) {
       private$client <- orderlyweb(host = host, port = port,
                                    token = token, https = https,
                                    prefix = prefix, name = name)
+      self$name <- name
     },
 
     list_reports = function() {

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -28,7 +28,7 @@ R6_orderlyweb_remote <- R6::R6Class(
       private$client <- orderlyweb(host = host, port = port,
                                    token = token, https = https,
                                    prefix = prefix, name = name)
-      self$name <- name
+      self$name <- private$client$api_client$name
     },
 
     list_reports = function() {

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -20,6 +20,7 @@ test_that("list", {
   res <- remote$list_reports()
   expect_is(res, "character")
   expect_true("minimal" %in% res)
+  expect_match(remote$name, "localhost")
 })
 
 

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -5,9 +5,10 @@ test_that("create", {
   skip_if_no_orderlyweb_server()
   token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
   remote <- orderlyweb_remote(host = "localhost", port = 8888,
-                              token = token, https = FALSE)
+                              token = token, https = FALSE, name = "remote")
   expect_is(remote, "orderlyweb_remote")
   expect_true(orderly:::implements_remote(remote))
+  expect_equal(remote$name, "remote")
 })
 
 


### PR DESCRIPTION
I need to enforce this in orderly too, and cope with failures...