### PR TITLE
vimc-3793: Support for pulling metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support For 'OrderlyWeb'
-Version: 0.1.7
+Version: 0.1.8
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderlyweb 0.1.8
+
+* Can return orderly run metadata (`orderly_run.rds`) from OrderlyWeb (VIMC-3793)
+
 # orderlyweb 0.1.3
 
 * The ability to run reports has been restored (VIMC-3138)

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -49,8 +49,8 @@ R6_orderlyweb_remote <- R6::R6Class(
       sprintf("%s/report/%s/%s/", private$client$api_client$url$www, name, id)
     },
 
-    metadata = function(name, id, dest = NULL) {
-      private$client$report_metadata_orderly(name, id, dest)
+    metadata = function(name, id) {
+      private$client$report_metadata_orderly(name, id)
     },
 
     run = function(name, parameters = NULL, ref = NULL, timeout = NULL,

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -49,6 +49,10 @@ R6_orderlyweb_remote <- R6::R6Class(
       sprintf("%s/report/%s/%s/", private$client$api_client$url$www, name, id)
     },
 
+    metadata = function(name, id, dest = NULL) {
+      private$client$report_metadata_orderly(name, id, dest)
+    },
+
     run = function(name, parameters = NULL, ref = NULL, timeout = NULL,
                    wait = 1000, poll = 1, progress = TRUE,
                    stop_on_error = TRUE, stop_on_timeout = TRUE, open = FALSE) {

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -73,6 +73,12 @@ R6_orderlyweb <- R6::R6Class(
       self$api_client$GET(sprintf("/reports/%s/versions/%s/", name, version))
     },
 
+    report_metadata_orderly = function(name, version, dest = NULL) {
+      download <- orderlyweb_download(dest, FALSE, "rds")
+      path <- sprintf("/reports/%s/versions/%s/run-meta", name, version)
+      self$api_client$GET(path, download = download)
+    },
+
     report_download = function(name, version, dest = NULL, progress = TRUE) {
       download <- orderlyweb_download(dest, progress, "zip")
       ret <- self$api_client$GET(

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -65,6 +65,23 @@ test_that("can fetch metadata", {
 })
 
 
+test_that("can fetch run metadata", {
+  cl <- test_orderlyweb()
+  d <- cl$report_list()
+
+  name <- "minimal"
+  version <- d$latest_version[d$name == name]
+
+  res <- cl$report_metadata_orderly(name, version)
+  expect_true(file.exists(res))
+
+  dat <- readRDS(res)
+  expect_equal(dat$meta$name, name)
+  expect_equal(dat$meta$id, version)
+  expect_true("description" %in% names(dat$meta))
+})
+
+
 test_that("download", {
   cl <- test_orderlyweb()
   d <- cl$report_list()

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -86,7 +86,7 @@ test_that("metadata", {
 
   path <- remote$pull("minimal", v, FALSE)
   meta <- remote$metadata("minimal", v)
-  ## There is a chance this will failing during a migration
+  ## There is a chance this will fail during a migration
   expect_identical(
     readRDS(meta),
     readRDS(file.path(path, "orderly_run.rds")))

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -76,6 +76,23 @@ test_that("pull", {
 })
 
 
+test_that("metadata", {
+  skip_if_no_orderlyweb_server()
+  token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
+  remote <- orderlyweb_remote(host = "localhost", port = 8888,
+                              token = token, https = FALSE)
+  dest <- orderly::orderly_example("demo")
+  v <- max(remote$list_versions("minimal"))
+
+  path <- remote$pull("minimal", v, FALSE)
+  meta <- remote$metadata("minimal", v)
+  ## There is a chance this will failing during a migration
+  expect_identical(
+    readRDS(meta),
+    readRDS(file.path(path, "orderly_run.rds")))
+})
+
+
 test_that("run", {
   skip_if_no_orderlyweb_server()
   token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")


### PR DESCRIPTION
This PR adds support for pulling metadata.  It exists to support vimc-3789, but is standalone.  The support for this was added ages ago into the OrderlyWeb api (https://github.com/vimc/orderly-web/pull/189, from 10 March).