### PR TITLE
VIMC-3819: Pass instance through orderlyweb to runner

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@
 ^\.travis\.yml$
 ^scripts$
 ^docs$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -51,12 +51,13 @@ R6_orderlyweb_remote <- R6::R6Class(
 
     run = function(name, parameters = NULL, ref = NULL, timeout = NULL,
                    wait = 1000, poll = 1, progress = TRUE,
-                   stop_on_error = TRUE, stop_on_timeout = TRUE, open = FALSE) {
+                   stop_on_error = TRUE, stop_on_timeout = TRUE, open = FALSE,
+                   instance = NULL) {
       private$client$report_run(name = name, parameters = parameters,
                                 ref = ref, timeout = timeout, wait = wait,
                                 poll = poll, open = open,
                                 stop_on_error = stop_on_error,
                                 stop_on_timeout = stop_on_timeout,
-                                progress = progress)
+                                progress = progress, instance = instance)
     }
   ))

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -132,8 +132,8 @@ R6_orderlyweb <- R6::R6Class(
                           update = TRUE, timeout = NULL, wait = Inf,
                           poll = 0.5, open = FALSE,
                           stop_on_error = FALSE, stop_on_timeout = TRUE,
-                          progress = TRUE) {
-      query <- report_run_query(ref, update, timeout)
+                          progress = TRUE, instance = NULL) {
+      query <- report_run_query(ref, update, timeout, instance)
       parameters <- report_run_parameters(parameters)
       res <- self$api_client$POST(sprintf("/reports/%s/run/", name),
                                   query = query, body = parameters,

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -33,7 +33,7 @@ report_run_wait <- function(path, name, key, client, timeout, poll, open,
 }
 
 
-report_run_query <- function(ref, update, timeout) {
+report_run_query <- function(ref, update, timeout, instance) {
   query <- list()
   if (!is.null(ref)) {
     query$ref <- ref
@@ -44,6 +44,9 @@ report_run_query <- function(ref, update, timeout) {
   if (!is.null(timeout)) {
     assert_scalar_integer(timeout)
     query$timeout <- as.character(timeout)
+  }
+  if (!is.null(instance)) {
+    query$instance <- instance
   }
   if (length(query) == 0L) {
     query <- NULL

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -11,7 +11,7 @@ orderly:
   image:
     repo: vimc
     name: orderly.server
-    tag: vimc-3820
+    tag: master
   initial:
     source: clone
     url: https://github.com/vimc/orderly-demo

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -11,7 +11,7 @@ orderly:
   image:
     repo: vimc
     name: orderly.server
-    tag: master 
+    tag: vimc-3820
   initial:
     source: clone
     url: https://github.com/vimc/orderly-demo

--- a/orderlyweb.Rproj
+++ b/orderlyweb.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -309,6 +309,27 @@ test_that("run: pass parameters", {
                sprintf("running report 'other' as '%s'\n", ans$key))
 })
 
+test_that("run: instance", {
+  cl <- test_orderlyweb()
+  res <- cl$report_run("minimal", poll = 0.1, instance = "other",
+                       progress = FALSE)
+  expect_equal(res$status, "error")
+  expect_true("Error: no such table: thing" %in% res$output$stderr)
+
+  res <- cl$report_run("minimal", poll = 0.1, instance = "missing",
+                       progress = FALSE)
+  expect_equal(res$status, "error")
+  expect_true("Error: Invalid instance 'missing' for database 'source'" %in%
+                res$output$stderr)
+
+  res <- cl$report_run("minimal", poll = 0.1, instance = "default",
+                       progress = FALSE)
+  expect_equal(names(res), c("name", "id", "status", "output", "url"))
+  expect_equal(res$status, "success")
+  expect_match(res$output$stderr, "[ name       ]  minimal",
+               fixed = TRUE, all = FALSE)
+})
+
 
 test_that("wait validation", {
   cl <- test_orderlyweb()

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -85,6 +85,22 @@ test_that("run", {
   expect_equal(max(remote$list_versions("minimal")), res$id)
 })
 
+test_that("run with instance", {
+  skip_if_no_orderlyweb_server()
+  token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
+  remote <- orderlyweb_remote(host = "localhost", port = 8888,
+                              token = token, https = FALSE)
+  expect_error(remote$run("minimal", open = FALSE, progress = FALSE,
+                          instance = "other"),
+               "Report has failed: see above for details")
+  expect_error(remote$run("minimal", open = FALSE, progress = FALSE,
+                          instance = "missing"),
+               "Report has failed: see above for details")
+  res <- remote$run("minimal", open = FALSE, progress = FALSE,
+                          instance = "default")
+  expect_equal(res$status, "success")
+})
+
 
 test_that("url_report returns expected url", {
   cl <- orderlyweb_remote("host", 8888, "token")
@@ -99,4 +115,13 @@ test_that("url_report includes prefix", {
   expect_equal(
     cl$url_report("name", "id"),
     "https://host:8888/prefix/report/name/id/")
+})
+
+test_that("run with instance", {
+  skip_if_no_orderlyweb_server()
+  token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
+  remote <- orderlyweb_remote(host = "localhost", port = 8888,
+                              token = token, https = FALSE)
+  res <- remote$run("minimal", open = FALSE, progress = FALSE)
+  expect_equal(max(remote$list_versions("minimal")), res$id)
 })

--- a/tests/testthat/test-report-run.R
+++ b/tests/testthat/test-report-run.R
@@ -54,19 +54,22 @@ test_that("progress - queued", {
 
 test_that("query", {
   expect_null(
-    report_run_query(NULL, TRUE, NULL))
+    report_run_query(NULL, TRUE, NULL, NULL))
   expect_equal(
-    report_run_query("ref", FALSE, NULL),
+    report_run_query("ref", FALSE, NULL, NULL),
     list(ref = "ref", update = "false"))
   expect_equal(
-    report_run_query("ref", TRUE, NULL),
+    report_run_query("ref", TRUE, NULL, NULL),
     list(ref = "ref"))
   expect_equal(
-    report_run_query("ref", TRUE, 1),
+    report_run_query("ref", TRUE, 1, NULL),
     list(ref = "ref", timeout = "1"))
   expect_equal(
-    report_run_query(NULL, TRUE, 1),
+    report_run_query(NULL, TRUE, 1, NULL),
     list(timeout = "1"))
+  expect_equal(
+    report_run_query(NULL, TRUE, NULL, "instance"),
+    list(instance = "instance"))
 })
 
 


### PR DESCRIPTION
We should merge
https://github.com/vimc/orderly/pull/228 and https://github.com/vimc/orderly.server/pull/21 before this (removing pins)
