### PR TITLE
vimc-4453: Add support for orderly bundles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Imports:
     R6,
     httr,
     jsonlite,
-    orderly (>= 1.2.18),
+    orderly (>= 1.2.19),
     progress,
     zip
 Suggests:
@@ -28,4 +28,4 @@ BugReports: https://github.com/vimc/orderlyweb/issues
 Encoding: UTF-8
 LazyData: true
 Remotes:
-    vimc/orderly
+    vimc/orderly@vimc-4457

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,4 +28,4 @@ BugReports: https://github.com/vimc/orderlyweb/issues
 Encoding: UTF-8
 LazyData: true
 Remotes:
-    vimc/orderly@vimc-4457
+    vimc/orderly

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,11 +16,11 @@ Imports:
     httr,
     jsonlite,
     orderly (>= 1.2.18),
-    progress
+    progress,
+    zip
 Suggests:
     mockery,
-    testthat,
-    zip
+    testthat
 RoxygenNote: 6.1.1
 License: MIT + file LICENSE
 URL: https://github.com/vimc/orderlyweb

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     progress
 Suggests:
     mockery,
-    testthat
+    testthat,
+    zip
 RoxygenNote: 6.1.1
 License: MIT + file LICENSE
 URL: https://github.com/vimc/orderlyweb

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support For 'OrderlyWeb'
-Version: 0.1.8
+Version: 0.1.9
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: orderlyweb
-Title: Orderly Support For 'OrderlyWeb'
+Title: Orderly Support for 'OrderlyWeb'
 Version: 0.1.9
 Authors@R:
     c(person(given = "Rich",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderlyweb 0.1.9
+
+* Add support for bundles (VIMC-4453)
+
 # orderlyweb 0.1.8
 
 * Can return orderly run metadata (`orderly_run.rds`) from OrderlyWeb (VIMC-3793)

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -63,5 +63,14 @@ R6_orderlyweb_remote <- R6::R6Class(
                                 stop_on_error = stop_on_error,
                                 stop_on_timeout = stop_on_timeout,
                                 progress = progress, instance = instance)
+    },
+
+    bundle_pack = function(name, parameters = NULL, instance = NULL,
+                           progress = TRUE) {
+      private$client$bundle_pack(name, parameters, instance, progress)
+    },
+
+    bundle_import = function(path, progress = TRUE) {
+      private$client$bundle_import(path, progress)
     }
   ))

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -209,7 +209,8 @@ R6_orderlyweb <- R6::R6Class(
       }
       download <- orderlyweb_download(tempfile(), progress, "zip")
       res <- self$api_client$POST(sprintf("/bundle/pack/%s/", name),
-                                  download = download)
+                                  body = parameters, download = download,
+                                  encode = "json", query = query)
 
       ## This is the underlying filename that we should use:
       filename <- paste0(sub("/.*", "", zip::zip_list(res)$filename[[1]]),

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -84,9 +84,7 @@ R6_orderlyweb <- R6::R6Class(
       ret <- self$api_client$GET(
         sprintf("/reports/%s/versions/%s/all/", name, version),
         download = download)
-      if (progress) {
-        cat("\n") # httr's progress bar is rubbish
-      }
+      fix_progress_print(progress)
       ret
     },
 
@@ -211,6 +209,7 @@ R6_orderlyweb <- R6::R6Class(
       res <- self$api_client$POST(sprintf("/bundle/pack/%s/", name),
                                   body = parameters, download = download,
                                   encode = "json", query = query)
+      fix_progress_print(progress)
 
       ## This is the underlying filename that we should use:
       filename <- paste0(sub("/.*", "", zip::zip_list(res)$filename[[1]]),

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -211,11 +211,9 @@ R6_orderlyweb <- R6::R6Class(
                                   encode = "json", query = query)
       fix_progress_print(progress)
 
-      ## This is the underlying filename that we should use:
       filename <- paste0(sub("/.*", "", zip::zip_list(res)$filename[[1]]),
                          ".zip")
 
-      ## Always save the temporary directory
       dest <- file.path(tempdir(), filename)
       fs::file_move(res, dest)
 

--- a/R/util.R
+++ b/R/util.R
@@ -76,3 +76,10 @@ format_output <- function(output) {
 squote <- function(x) {
   sprintf("'%s'", x)
 }
+
+
+fix_progress_print <- function(progress) {
+  if (progress) {
+    cat("\n") # httr's progress bar is rubbish
+  }
+}

--- a/R/util.R
+++ b/R/util.R
@@ -80,6 +80,6 @@ squote <- function(x) {
 
 fix_progress_print <- function(progress) {
   if (progress) {
-    cat("\n") # httr's progress bar is rubbish
+    cat("\n") # httr's progress bar is rubbish for requests of unknown size
   }
 }

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -398,3 +398,27 @@ test_that("can pack a bundle", {
 
   expect_true(ans$id %in% cl$report_versions("minimal"))
 })
+
+
+test_that("can pass parameters to bundle pack", {
+  cl <- test_orderlyweb()
+  res <- cl$bundle_pack("other", list(nmin = 0.5), progress = FALSE)
+
+  tmp <- tempfile()
+  ans <- zip::unzip(res, exdir = tmp)
+  expect_equal(
+    readRDS(file.path(tmp, dir(tmp), "meta", "info.rds"))$parameters,
+    list(nmin = 0.5))
+})
+
+
+test_that("can pass instance to bundle pack", {
+  cl <- test_orderlyweb()
+  res <- cl$bundle_pack("minimal", instance = "default", progress = FALSE)
+
+  tmp <- tempfile()
+  ans <- zip::unzip(res, exdir = tmp)
+  expect_equal(
+    readRDS(file.path(tmp, dir(tmp), "meta", "info.rds"))$instance,
+    "default")
+})

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -381,3 +381,20 @@ test_that("timeout without error", {
                             stop_on_timeout = FALSE)
   expect_equal(res$status, "success")
 })
+
+
+test_that("can pack a bundle", {
+  cl <- test_orderlyweb()
+  res <- cl$bundle_pack("minimal", progress = FALSE)
+  expect_true(file.exists(res))
+  expect_equal(dirname(res), tempdir())
+  expect_match(basename(res), "^[0-9]{8}-[0-9]{6}-[[:xdigit:]]{8}\\.zip$")
+
+  ans <- orderly::orderly_bundle_run(res, echo = FALSE)
+  expect_equal(ans$id, sub("\\.zip$", "", basename(res)))
+  expect_false(ans$id %in% cl$report_versions("minimal"))
+
+  cl$bundle_import(ans$path, progress = FALSE)
+
+  expect_true(ans$id %in% cl$report_versions("minimal"))
+})

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -155,3 +155,19 @@ test_that("bundle interface", {
   expect_true(remote$bundle_import(ans$path, progress = FALSE))
   expect_true(ans$id %in% remote$list_versions("minimal"))
 })
+
+
+test_that("bundle high level interface", {
+  skip_if_no_orderlyweb_server()
+  token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
+  remote <- orderlyweb_remote(host = "localhost", port = 8888,
+                              token = token, https = FALSE)
+
+  capture.output(
+    res <- orderly::orderly_bundle_pack_remote("minimal", remote = remote))
+  ans <- orderly::orderly_bundle_run(res, echo = FALSE)
+  capture.output(
+    res <- orderly::orderly_bundle_import_remote(ans$path, remote = remote))
+
+  expect_true(ans$id %in% remote$list_versions("minimal"))
+})

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -142,3 +142,16 @@ test_that("run with instance", {
   res <- remote$run("minimal", open = FALSE, progress = FALSE)
   expect_equal(max(remote$list_versions("minimal")), res$id)
 })
+
+
+test_that("bundle interface", {
+  skip_if_no_orderlyweb_server()
+  token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
+  remote <- orderlyweb_remote(host = "localhost", port = 8888,
+                              token = token, https = FALSE)
+
+  res <- remote$bundle_pack("minimal", progress = FALSE)
+  ans <- orderly::orderly_bundle_run(res, echo = FALSE)
+  expect_true(remote$bundle_import(ans$path, progress = FALSE))
+  expect_true(ans$id %in% remote$list_versions("minimal"))
+})


### PR DESCRIPTION
Adds support for orderly bundles (pack and import) now that this is supported in OrderlyWeb.

Only the happy paths are tested here as the unhappy paths (incorrect parameters, etc) need better handling in orderly.server as they are throwing 500 errors at the moment; see VIMC-4455

Companion PR here: https://github.com/vimc/orderly/pull/258