### PR TITLE
VIMC-4557: Update orderlyweb to work with orderly.server refactor

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up orderly-web
         run: |
           pip3 install orderly-web
-          orderly-web start inst/config
+          orderly-web start --pull inst/config
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -63,5 +63,5 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        run: covr::codecov(quiet = FALSE)
+        run: covr::codecov()
         shell: Rscript {0}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up orderly-web
         run: |
           pip3 install orderly-web
-          orderly-web start inst/config
+          orderly-web start --pull inst/config
 
       - uses: r-lib/actions/setup-pandoc@v1
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -63,5 +63,5 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        run: covr::codecov()
+        run: covr::codecov(quiet = FALSE)
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support for 'OrderlyWeb'
-Version: 0.1.9
+Version: 0.1.10
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",
@@ -13,6 +13,7 @@ Description: Client for 'OrderlyWeb' for use from the 'orderly'
     and other interaction with the remote report repository.
 Imports:
     R6,
+    gert,
     httr,
     jsonlite,
     orderly (>= 1.2.19),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# orderlyweb 0.1.10
+
+* Update to work with orderly.server v0.2.6
+   * Report run status now returns queue info in a separate section
+   * Report run output now returns 1 list
+   * Update arg to report run has been removed
+
 # orderlyweb 0.1.9
 
 * Add support for bundles (VIMC-4453)

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -137,10 +137,10 @@ R6_orderlyweb <- R6::R6Class(
                           poll = 0.5, open = FALSE,
                           stop_on_error = FALSE, stop_on_timeout = TRUE,
                           progress = TRUE, instance = NULL) {
-      query <- report_run_query(ref, timeout, instance)
-      parameters <- report_run_parameters(parameters)
+      query <- report_run_query(timeout)
+      body <- report_run_body(parameters, ref, instance)
       res <- self$api_client$POST(sprintf("/reports/%s/run/", name),
-                                  query = query, body = parameters,
+                                  query = query, body = body,
                                   encode = "json")
       class(res) <- "orderlyweb_run"
 

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -133,11 +133,11 @@ R6_orderlyweb <- R6::R6Class(
     },
 
     report_run = function(name, parameters = NULL, ref = NULL,
-                          update = TRUE, timeout = NULL, wait = Inf,
+                          timeout = NULL, wait = Inf,
                           poll = 0.5, open = FALSE,
                           stop_on_error = FALSE, stop_on_timeout = TRUE,
                           progress = TRUE, instance = NULL) {
-      query <- report_run_query(ref, update, timeout, instance)
+      query <- report_run_query(ref, timeout, instance)
       parameters <- report_run_parameters(parameters)
       res <- self$api_client$POST(sprintf("/reports/%s/run/", name),
                                   query = query, body = parameters,

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -90,7 +90,7 @@ report_wait_progress <- function(key, progress, force = FALSE) {
 
   fmt <- sprintf("[:spin] (%s) :elapsed :status", key)
   p <- progress::progress_bar$new(fmt, NA, show_after = 0, force = force)
-  prev_output <- list(stderr = NULL, stdout = NULL)
+  prev_output <- NULL
   w <- getOption("width", 80L)
 
   new <- function(now, prev) {
@@ -103,22 +103,22 @@ report_wait_progress <- function(key, progress, force = FALSE) {
 
   tick <- function(response, finish = FALSE) {
     state <- response$status
+    queue <- response$queue
     output <- response$output
     version <- response$version %||% "???"
 
     if (state == "queued") {
-      queue <- matrix(
-        unlist(strsplit(output$stdout, ":", fixed = TRUE)),
-        length(output$stdout), byrow = TRUE)
-      status <- trim_string(sprintf(
-        "queued (%d): %s", nrow(queue), paste(queue[, 3], collapse = " < ")),
-        w - 12L)
+      queued <- vcapply(queue, function(item) {
+        item$name
+      })
+      status <- sprintf("queued (%d): %s", length(queue),
+                        paste(queued, collapse = " < "))
     } else {
       status <- sprintf("%s: %s", state, version)
     }
 
-    if (state %in% c("running", "error", "success") && !is.null(output)) {
-      new_output <- Map(new, output, prev_output)
+    if (state != "queued" && !is.null(output)) {
+      new_output <- new(output, prev_output)
       if (any(lengths(new_output)) > 0L) {
         clear_progress_bar(p)
         message(format_output(new_output), appendLF = FALSE)
@@ -144,13 +144,14 @@ report_wait_cleanup <- function(name, ans, progress, stop_on_error,
     ans <- client$report_run_status(ans$key, TRUE)
   }
 
-  if (stop_on_error && ans$status %in% c("error", "killed")) {
+  if (stop_on_error && ans$status %in%
+      c("error", "orphan", "interrupted", "redirect", "missing")) {
     ## TODO: It would be super nice to get the full stack trace back
     ## here from orderly on error.  That should not be hard to do.
     if (!progress) {
       cat(format_output(ans$output))
     }
-    if (ans$status == "killed") {
+    if (ans$status == "interrupted") {
       stop("job killed by remote server", call. = FALSE)
     } else {
       stop("Report has failed: see above for details", call. = FALSE)

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -33,22 +33,41 @@ report_run_wait <- function(path, name, key, client, timeout, poll, open,
 }
 
 
-report_run_query <- function(ref, timeout, instance) {
-  query <- list()
-  if (!is.null(ref)) {
-    query$ref <- ref
-  }
+report_run_query <- function(timeout) {
   if (!is.null(timeout)) {
     assert_scalar_integer(timeout)
-    query$timeout <- as.character(timeout)
-  }
-  if (!is.null(instance)) {
-    query$instance <- instance
-  }
-  if (length(query) == 0L) {
+    query <- list(
+      timeout = as.character(timeout)
+    )
+  } else {
     query <- NULL
   }
   query
+}
+
+report_run_body <- function(parameters, ref, instance) {
+  body <- list()
+  if (!is.null(ref)) {
+    assert_scalar_character(ref)
+    body$gitCommit <- ref
+  }
+  if (!is.null(instance)) {
+    ## Instance can be single string
+    ## Or named of instances e.g. list(source = x, annex = f)
+    if (is.character(instance)) {
+      ## TODO: name "source" should not be hard coded and this
+      ## default should depend on the particular orderly configuration
+      ## see VIMC-4587
+      body$instances <- list(source = instance)
+    } else if (is.list(instance)) {
+      body$instances <- instance
+    }
+  }
+  body$params <- report_run_parameters(parameters)
+  if (length(body) == 0) {
+    body <- NULL
+  }
+  body
 }
 
 

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -49,7 +49,7 @@ report_run_body <- function(parameters, ref, instance) {
   body <- list()
   if (!is.null(ref)) {
     assert_scalar_character(ref)
-    body$gitCommit <- ref
+    body[["gitCommit"]] <- ref
   }
   if (!is.null(instance)) {
     ## Instance can be single string
@@ -58,12 +58,12 @@ report_run_body <- function(parameters, ref, instance) {
       ## TODO: name "source" should not be hard coded and this
       ## default should depend on the particular orderly configuration
       ## see VIMC-4587
-      body$instances <- list(source = instance)
+      body[["instances"]] <- list(source = instance)
     } else if (is.list(instance)) {
-      body$instances <- instance
+      body[["instances"]] <- instance
     }
   }
-  body$params <- report_run_parameters(parameters)
+  body[["params"]] <- report_run_parameters(parameters)
   if (length(body) == 0) {
     body <- NULL
   }

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -33,13 +33,10 @@ report_run_wait <- function(path, name, key, client, timeout, poll, open,
 }
 
 
-report_run_query <- function(ref, update, timeout, instance) {
+report_run_query <- function(ref, timeout, instance) {
   query <- list()
   if (!is.null(ref)) {
     query$ref <- ref
-  }
-  if (!update) {
-    query$update <- "false"
   }
   if (!is.null(timeout)) {
     assert_scalar_integer(timeout)

--- a/R/util.R
+++ b/R/util.R
@@ -69,7 +69,7 @@ trim_string <- function (s, w, elipsis = " ...") {
 
 
 format_output <- function(output) {
-  paste(sprintf("%s\n", c(output$stderr, output$stdout)), collapse = "")
+  paste0(paste(output, collapse = "\n"), "\n")
 }
 
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To stop the server, use `orderly-web stop inst/config --volumes --kill`
 ```r
 # install.packages("drat")
 drat:::add("vimc")
-install.packages("orderly")
+install.packages("orderlyweb")
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The R package [`orderly`](https://github.com/vimc/orderly) has a [web interface 
 
 ### Testing
 
-For end-to-end testing, we need a copy of orderlyweb running.  This is most easily set up using the provided configuration ([`inst/config`](inst/config)) and running `orderly-web start inst/config` before running the tests.  The test suite will make changes within the configuration and will rely on the existance of particular reports.
+For end-to-end testing, we need a copy of orderlyweb running.  This is most easily set up using the provided configuration ([`inst/config`](inst/config)) and running `orderly-web start --pull inst/config` before running the tests.  The test suite will make changes within the configuration and will rely on the existence of particular reports.
 
 To install `orderly-web` (the command line tool) use `pip3 install orderly-web`
 

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -19,8 +19,8 @@ orderly:
   image:
     repo: vimc
     name: orderly.server
-    tag: vimc-4573 
-    worker_name: orderly.server-worker
+    tag: vimc-4192 
+    worker_name: orderly.server
   initial:
     source: clone
     url: https://github.com/vimc/orderly-demo

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -19,7 +19,7 @@ orderly:
   image:
     repo: vimc
     name: orderly.server
-    tag: vimc-4192 
+    tag: master 
     worker_name: orderly.server
   initial:
     source: clone
@@ -30,7 +30,7 @@ web:
   image:
     repo: vimc
     name: orderly-web
-    tag: mrc-2165 
+    tag: master 
     migrate: orderlyweb-migrate
     admin: orderly-web-user-cli
   url: https://localhost

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -5,22 +5,32 @@ network: orderly_web_network
 volumes:
   orderly: orderly_web_volume
   proxy_logs: orderly_web_proxy_logs
+  redis: orderly_web_redis_data
+
+redis:
+  image:
+    name: redis
+    tag: "5.0"
+  volume: orderly_web_redis_data
+
 
 ## Orderly configuration
 orderly:
   image:
     repo: vimc
     name: orderly.server
-    tag: master
+    tag: vimc-4573 
+    worker_name: orderly.server-worker
   initial:
     source: clone
     url: https://github.com/vimc/orderly-demo
+  workers: 1
 
 web:
   image:
     repo: vimc
     name: orderly-web
-    tag: master
+    tag: mrc-2165 
     migrate: orderlyweb-migrate
     admin: orderly-web-user-cli
   url: https://localhost

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -375,7 +375,7 @@ test_that("timeout without error", {
   res <- cl$report_run_wait(ans, timeout = 2, poll = 0, progress = FALSE,
                             stop_on_timeout = FALSE)
   expect_equal(res$status, "running")
-  res <- cl$report_run_wait(ans, timeout = 10, poll = 0, progress = FALSE,
+  res <- cl$report_run_wait(ans, timeout = 15, poll = 0, progress = FALSE,
                             stop_on_timeout = FALSE)
   expect_equal(res$status, "success")
 })

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -269,10 +269,9 @@ test_that("run: simple", {
   expect_equal(names(res), c("name", "id", "status", "output", "url"))
   expect_equal(res$name, "minimal")
   expect_equal(res$status, "success")
-  expect_setequal(names(res$output), c("stderr", "stdout"))
   expect_equal(res$url,
                paste0("http://localhost:8888/report/minimal/", res$id))
-  expect_match(res$output$stderr, "[ name       ]  minimal",
+  expect_match(res$output, "[ name       ]  minimal",
                fixed = TRUE, all = FALSE)
 })
 
@@ -284,10 +283,9 @@ test_that("run: simple", {
   expect_equal(names(res), c("name", "id", "status", "output", "url"))
   expect_equal(res$name, "minimal")
   expect_equal(res$status, "success")
-  expect_setequal(names(res$output), c("stderr", "stdout"))
   expect_equal(res$url,
                paste0("http://localhost:8888/report/minimal/", res$id))
-  expect_match(res$output$stderr, "[ name       ]  minimal",
+  expect_match(res$output, "[ name       ]  minimal",
                fixed = TRUE, all = FALSE)
 })
 
@@ -323,7 +321,7 @@ test_that("run: pass parameters", {
   res <- cl$report_run_wait(ans, progress = FALSE)
   expect_equal(res$name, "other")
 
-  expect_match(res$output$stderr, "nmin: 0.5", all = FALSE, fixed = TRUE)
+  expect_match(res$output, "nmin: 0.5", all = FALSE, fixed = TRUE)
 
   msg <- capture_messages(cl$report_run_wait(ans, progress = TRUE))
   expect_equal(msg[[1]],
@@ -335,19 +333,19 @@ test_that("run: instance", {
   res <- cl$report_run("minimal", poll = 0.1, instance = "other",
                        progress = FALSE)
   expect_equal(res$status, "error")
-  expect_true("Error: no such table: thing" %in% res$output$stderr)
+  expect_true("Error: no such table: thing" %in% res$output)
 
   res <- cl$report_run("minimal", poll = 0.1, instance = "missing",
                        progress = FALSE)
   expect_equal(res$status, "error")
   expect_true("Error: Invalid instance 'missing' for database 'source'" %in%
-                res$output$stderr)
+                res$output)
 
   res <- cl$report_run("minimal", poll = 0.1, instance = "default",
                        progress = FALSE)
   expect_equal(names(res), c("name", "id", "status", "output", "url"))
   expect_equal(res$status, "success")
-  expect_match(res$output$stderr, "[ name       ]  minimal",
+  expect_match(res$output, "[ name       ]  minimal",
                fixed = TRUE, all = FALSE)
 })
 

--- a/tests/testthat/test-report-run.R
+++ b/tests/testthat/test-report-run.R
@@ -68,21 +68,21 @@ test_that("progress - queued", {
 
 test_that("query", {
   expect_null(
-    report_run_query(NULL, TRUE, NULL, NULL))
+    report_run_query(NULL, NULL, NULL))
   expect_equal(
-    report_run_query("ref", FALSE, NULL, NULL),
-    list(ref = "ref", update = "false"))
-  expect_equal(
-    report_run_query("ref", TRUE, NULL, NULL),
+    report_run_query("ref", NULL, NULL),
     list(ref = "ref"))
   expect_equal(
-    report_run_query("ref", TRUE, 1, NULL),
+    report_run_query("ref", NULL, NULL),
+    list(ref = "ref"))
+  expect_equal(
+    report_run_query("ref", 1, NULL),
     list(ref = "ref", timeout = "1"))
   expect_equal(
-    report_run_query(NULL, TRUE, 1, NULL),
+    report_run_query(NULL, 1, NULL),
     list(timeout = "1"))
   expect_equal(
-    report_run_query(NULL, TRUE, NULL, "instance"),
+    report_run_query(NULL, NULL, "instance"),
     list(instance = "instance"))
 })
 

--- a/tests/testthat/test-report-run.R
+++ b/tests/testthat/test-report-run.R
@@ -68,22 +68,10 @@ test_that("progress - queued", {
 
 test_that("query", {
   expect_null(
-    report_run_query(NULL, NULL, NULL))
+    report_run_query(NULL))
   expect_equal(
-    report_run_query("ref", NULL, NULL),
-    list(ref = "ref"))
-  expect_equal(
-    report_run_query("ref", NULL, NULL),
-    list(ref = "ref"))
-  expect_equal(
-    report_run_query("ref", 1, NULL),
-    list(ref = "ref", timeout = "1"))
-  expect_equal(
-    report_run_query(NULL, 1, NULL),
+    report_run_query(1),
     list(timeout = "1"))
-  expect_equal(
-    report_run_query(NULL, NULL, "instance"),
-    list(instance = "instance"))
 })
 
 
@@ -107,6 +95,21 @@ test_that("parameters", {
   expect_error(report_run_parameters(list(a = 1:2, b = 2)),
                "All parameters must be scalar (check 'a')",
                fixed = TRUE)
+})
+
+test_that("body", {
+  expect_null(report_run_body(NULL, NULL, NULL))
+  expect_equal(report_run_body(list(a = 1, b = 2), NULL, NULL),
+               list(
+                  params = report_run_parameters(list(a = 1, b = 2))))
+  expect_equal(report_run_body(NULL, "12345", NULL),
+               list(gitCommit = "12345"))
+  expect_equal(report_run_body(NULL, NULL, "science"),
+               list(instances = list(source = "science")))
+  expect_equal(report_run_body(NULL, NULL, list(source = "science",
+                                                annex = "annex")),
+               list(instances = list(source = "science",
+                                     annex = "annex")))
 })
 
 

--- a/tests/testthat/test-report-run.R
+++ b/tests/testthat/test-report-run.R
@@ -19,18 +19,19 @@ test_that("progress - with output", {
   id <- "20190805-153610-eebad7d5"
   expect_is(p, "function")
   msg <- capture_messages(
-    p(list(status = "running", version = id, output = list(stdout = "a"))))
+    p(list(status = "running", version = id, output = list("a"),
+           queue = list())))
   expect_equal(msg[1:3], c("\r", "a\n", "\r"))
   expect_match(msg[[4]], "running: 20190805-153610-eebad7d5")
 
   msg <- capture_messages(
-    p(list(status = "running", version = id, output = list(stdout = "a"))))
+    p(list(status = "running", version = id, output = list("a"))))
   expect_equal(length(msg), 2)
   expect_match(msg[[2]], "running: 20190805-153610-eebad7d5")
 
   msg <- capture_messages(
     p(list(status = "running", version = id,
-           output = list(stdout = c("a", "b", "c")))))
+           output = list("a", "b", "c"))))
   expect_equal(msg[2:4], c("\r", "b\nc\n", "\r"))
   expect_match(msg[[5]], "running: 20190805-153610-eebad7d5")
 })
@@ -41,13 +42,26 @@ test_that("progress - queued", {
   id <- "20190805-153610-eebad7d5"
   expect_is(p, "function")
   msg <- capture_messages(
-    p(list(status = "queued", version = id,
-           output = list(stdout =
-                           c("running:key1:name1", "queued:key2:name2")))))
+    p(list(status = "queued", version = id, output = list(),
+           queue = list(
+             list(
+               key = "key1",
+               status = "running",
+               name = "name1"
+             ),
+             list(
+               key = "key2",
+               status = "queued",
+               name = "name2"
+             )))))
   expect_equal(msg[[2]], "[-] (key)  0s queued (2): name1 < name2")
   msg <- capture_messages(
-    p(list(status = "queued", version = id,
-           output = list(stdout = c("running:key2:name2")))))
+    p(list(status = "queued", version = id, output = list(),
+           queue = list(list(
+             key = "key2",
+             status = "running",
+             name = "name2"
+           )))))
   expect_equal(msg[[3]], "[\\] (key)  0s queued (1): name2")
 })
 
@@ -100,14 +114,14 @@ test_that("cleanup", {
   client <- NULL
   ans <- list(status = "error",
               version = "id",
-              output = list(stderr = "stderr", stdout = "stdout"))
+              output = list("output"))
   out <- capture_output(
     expect_error(
       report_wait_cleanup("name", ans, FALSE, TRUE, FALSE, client),
       "Report has failed: see above for details"))
   expect_equal(out, trimws(format_output(ans$output)))
 
-  ans$status <- "killed"
+  ans$status <- "interrupted"
   out <- capture_output(
     expect_error(
       report_wait_cleanup("name", ans, FALSE, TRUE, FALSE, client),
@@ -116,7 +130,7 @@ test_that("cleanup", {
 
   expect_equal(
     report_wait_cleanup("name", ans, FALSE, FALSE, FALSE, client),
-    list(name = "name", id = "id", status = "killed", output = ans$output,
+    list(name = "name", id = "id", status = "interrupted", output = ans$output,
          url = NULL))
 })
 
@@ -129,7 +143,7 @@ test_that("cleanup - open url", {
                    list(url = list(www = "https://example.com/reports")))
   ans <- list(status = "success",
               version = "id",
-              output = list(stderr = "stderr", stdout = "stdout"))
+              output = list("output"))
 
   m <- mockery::mock()
   mockery::stub(report_wait_cleanup, "utils::browseURL", m)


### PR DESCRIPTION
This will:
* Update to return progress from new format of queue info (i.e. queue info no longer in `output` but is in a separate `queue` section and contains info on name, status and key of run)
* Remove `update` arg to report runner as this is no longer supported
* Removed separation of `stderr` and `stdout` in `output` section of `status` response, this is now merged output

This is part of big refactor and should be left open until we are ready to merge it all see https://mrc-ide.myjetbrains.com/youtrack/issue/VIMC-4192

This is failing tests atm because the version of orerly-web hasn't been updated on pypi - it works when running locally
