### PR TITLE
VIMC-4637: Add function to show queue status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support for 'OrderlyWeb'
-Version: 0.1.11
+Version: 0.1.12
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/orderly.R
+++ b/R/orderly.R
@@ -72,5 +72,9 @@ R6_orderlyweb_remote <- R6::R6Class(
 
     bundle_import = function(path, progress = TRUE) {
       private$client$bundle_import(path, progress)
+    },
+
+    queue_status = function() {
+      private$client$queue_status()
     }
   ))

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -248,6 +248,10 @@ R6_orderlyweb <- R6::R6Class(
 
     git_fetch = function(client = NULL) {
       self$api_client$POST("/reports/git/fetch/")
+    },
+
+    queue_status = function() {
+      self$api_client$GET("/queue/status/")
     }
   ))
 

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -19,7 +19,7 @@ orderly:
   image:
     repo: vimc
     name: orderly.server
-    tag: vimc-4556 
+    tag: master 
     worker_name: orderly.server
   initial:
     source: clone

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -19,7 +19,7 @@ orderly:
   image:
     repo: vimc
     name: orderly.server
-    tag: master 
+    tag: vimc-4556 
     worker_name: orderly.server
   initial:
     source: clone

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -425,7 +425,7 @@ test_that("can pass instance to bundle pack", {
 test_that("queue status", {
   cl <- test_orderlyweb()
   run <- cl$report_run("slow3", open = FALSE, progress = FALSE, wait = FALSE)
-  Sys.sleep(1) ## Ensure report gets started
+  Sys.sleep(2) ## Ensure report gets started
   res <- cl$queue_status()
   expect_length(res$tasks, 1)
   expect_equal(res$tasks[[1]]$name, "slow3")

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -420,3 +420,16 @@ test_that("can pass instance to bundle pack", {
     readRDS(file.path(tmp, dir(tmp), "meta", "info.rds"))$instance,
     "default")
 })
+
+
+test_that("queue status", {
+  cl <- test_orderlyweb()
+  run <- cl$report_run("slow3", open = FALSE, progress = FALSE, wait = FALSE)
+  Sys.sleep(1) ## Ensure report gets started
+  res <- cl$queue_status()
+  expect_length(res$tasks, 1)
+  expect_equal(res$tasks[[1]]$name, "slow3")
+  expect_true(!is.null(res$tasks[[1]]$version))
+  expect_equal(res$tasks[[1]]$key, run$key)
+  expect_equal(res$tasks[[1]]$status, "running")
+})

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -179,7 +179,7 @@ test_that("queue status", {
   remote <- orderlyweb_remote(host = "localhost", port = 8888,
                               token = token, https = FALSE)
   out <- remote$run("slow3", open = FALSE, progress = FALSE, wait = FALSE)
-  Sys.sleep(1) ## Ensure report gets started
+  Sys.sleep(2) ## Ensure report gets started
   res <- remote$queue_status()
   expect_length(res$tasks, 1)
   expect_equal(res$tasks[[1]]$name, "slow3")

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -172,11 +172,18 @@ test_that("bundle high level interface", {
   expect_true(ans$id %in% remote$list_versions("minimal"))
 })
 
+
 test_that("queue status", {
   skip_if_no_orderlyweb_server()
   token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
   remote <- orderlyweb_remote(host = "localhost", port = 8888,
                               token = token, https = FALSE)
-  remote$run("minimal", open = FALSE, progress = FALSE)
+  out <- remote$run("slow3", open = FALSE, progress = FALSE, wait = FALSE)
+  Sys.sleep(1) ## Ensure report gets started
   res <- remote$queue_status()
+  expect_length(res$tasks, 1)
+  expect_equal(res$tasks[[1]]$name, "slow3")
+  expect_true(!is.null(res$tasks[[1]]$version))
+  expect_equal(res$tasks[[1]]$key, out$key)
+  expect_equal(res$tasks[[1]]$status, "running")
 })

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -171,3 +171,12 @@ test_that("bundle high level interface", {
 
   expect_true(ans$id %in% remote$list_versions("minimal"))
 })
+
+test_that("queue status", {
+  skip_if_no_orderlyweb_server()
+  token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
+  remote <- orderlyweb_remote(host = "localhost", port = 8888,
+                              token = token, https = FALSE)
+  remote$run("minimal", open = FALSE, progress = FALSE)
+  res <- remote$queue_status()
+})


### PR DESCRIPTION
This picks up on something Katy asked for ages ago which I had finished half of but never done the orderly & orderlyweb sides of things. This is to add a function `orderly_remote_status` to show the status of the queue to orderly user