### PR TITLE
Update orderlyweb to handle latest format of queue status

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support for 'OrderlyWeb'
-Version: 0.1.13
+Version: 0.1.14
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# orderlyweb 0.1.14
+
+* Update report run wait handling to use latest queue status format (orderly.server v0.3.25)
+
 # orderlyweb 0.1.13
 
 * Expose report kill endpoint

--- a/R/orderlyweb_run.R
+++ b/R/orderlyweb_run.R
@@ -125,7 +125,7 @@ report_wait_progress <- function(key, progress, force = FALSE) {
 
     if (state == "queued") {
       queued <- vcapply(queue, function(item) {
-        item$name
+        item$inputs$name
       })
       status <- sprintf("queued (%d): %s", length(queue),
                         paste(queued, collapse = " < "))

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -428,7 +428,7 @@ test_that("queue status", {
   Sys.sleep(2) ## Ensure report gets started
   res <- cl$queue_status()
   expect_length(res$tasks, 1)
-  expect_equal(res$tasks[[1]]$name, "slow3")
+  expect_equal(res$tasks[[1]]$inputs$name, "slow3")
   expect_true(!is.null(res$tasks[[1]]$version))
   expect_equal(res$tasks[[1]]$key, run$key)
   expect_equal(res$tasks[[1]]$status, "running")

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -182,7 +182,7 @@ test_that("queue status", {
   Sys.sleep(2) ## Ensure report gets started
   res <- remote$queue_status()
   expect_length(res$tasks, 1)
-  expect_equal(res$tasks[[1]]$name, "slow3")
+  expect_equal(res$tasks[[1]]$inputs$name, "slow3")
   expect_true(!is.null(res$tasks[[1]]$version))
   expect_equal(res$tasks[[1]]$key, out$key)
   expect_equal(res$tasks[[1]]$status, "running")

--- a/tests/testthat/test-report-run.R
+++ b/tests/testthat/test-report-run.R
@@ -47,12 +47,26 @@ test_that("progress - queued", {
              list(
                key = "key1",
                status = "running",
-               name = "name1"
+               version = "id1",
+               inputs = list(
+                 name = "name1",
+                 params = NULL,
+                 ref = NULL,
+                 instance = NULL,
+                 changelog = NULL
+               )
              ),
              list(
                key = "key2",
                status = "queued",
-               name = "name2"
+               version = NULL,
+               inputs = list(
+                 name = "name2",
+                 params = list(time = 10, poll = 1),
+                 ref = "1234",
+                 instance = "production",
+                 changelog = "[internal] changelog message"
+               )
              )))))
   expect_equal(msg[[2]], "[-] (key)  0s queued (2): name1 < name2")
   msg <- capture_messages(
@@ -60,7 +74,14 @@ test_that("progress - queued", {
            queue = list(list(
              key = "key2",
              status = "running",
-             name = "name2"
+             version = "123",
+             inputs = list(
+               name = "name2",
+               params = list(time = 10, poll = 1),
+               ref = "1234",
+               instance = "production",
+               changelog = "[internal] changelog message"
+             )
            )))))
   expect_equal(msg[[3]], "[\\] (key)  0s queued (1): name2")
 })


### PR DESCRIPTION
The format changed in https://github.com/vimc/orderly.server/pull/99/files, this PR will update the parsing of queue response to work with latest format