### PR TITLE
vimc-6946 update OW api

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Set up orderly-web
         run: |
+          pip3 install constellation
           pip3 install orderly-web
           orderly-web start --pull inst/config
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Set up orderly-web
         run: |
+          pip3 install constellation
           pip3 install orderly-web
           orderly-web start --pull inst/config
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vignettes/*.html
 build
 docs
 tests/testthat/montagu-reports
+.idea

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support for 'OrderlyWeb'
-Version: 0.1.14
+Version: 0.1.15
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -110,7 +110,7 @@ R6_orderlyweb_api_client <- R6::R6Class(
 
       r <- do_request()
       if (httr::status_code(r) == 401L) {
-        errors <- vcapply(response_to_json(r)$errors, "[[", "code")
+        errors <- vcapply(response_to_json(r)$errors, "[[", "error")
         if ("bearer-token-invalid" %in% errors) {
           self$authorise(TRUE)
           r <- do_request()
@@ -149,10 +149,10 @@ orderlyweb_api_client_name <- function(name, host, port, prefix) {
 ## For our current systems we have:
 ##
 ## We have apis at:
-##   https://ebola2018.dide.ic.ac.uk/api/v1/
-##   https://support.montagu.dide.ic.ac.uk:10443/reports/api/v1/
+##   https://ebola2018.dide.ic.ac.uk/api/v2/
+##   https://support.montagu.dide.ic.ac.uk:10443/reports/api/v2/
 ##
-## <protocol>://<host>:<port><prefix>/api/v1
+## <protocol>://<host>:<port><prefix>/api/v2
 orderlyweb_api_client_url <- function(host, port, https, prefix,
                                       api_version) {
   assert_scalar_character(host)
@@ -189,7 +189,7 @@ orderlyweb_api_client_response <- function(r, download) {
   if (code >= 300) {
     if (is_json_response(r)) {
       res <- response_to_json(r)
-      stop(orderlyweb_api_error(res$errors[[1]]$message, code, res$errors))
+      stop(orderlyweb_api_error(res$errors[[1]]$detail, code, res$errors))
     }
     ## This should never really be used - it's just for when things go
     ## really pear shaped.

--- a/R/api_client.R
+++ b/R/api_client.R
@@ -41,7 +41,7 @@
 ##'                                         token = "mytoken")
 ##' cl$is_authorised()
 orderlyweb_api_client <- function(host, port, token, name = NULL,
-                                  https = TRUE, prefix = NULL, api_version = 1,
+                                  https = TRUE, prefix = NULL, api_version = 2,
                                   insecure = FALSE, verbose = FALSE) {
   R6_orderlyweb_api_client$new(host, port, token, name = name,
                                https = https, prefix = prefix,

--- a/R/orderlyweb.R
+++ b/R/orderlyweb.R
@@ -271,7 +271,7 @@ report_versions_return <- function(res, error_if_missing) {
   } else if (allow_missing &&
              inherits(res, "orderlyweb_api_error") &&
              length(res$errors) == 1L &&
-             res$errors[[1]]$code == "unknown-report") {
+             res$errors[[1]]$error == "unknown-report") {
     return(character(0))
   } else {
     stop(res)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ drat:::add("vimc")
 install.packages("orderlyweb")
 ```
 
+If upgrading, make sure to open a new session for the changes to take effect.
+
 ## License
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -30,7 +30,7 @@ web:
   image:
     repo: vimc
     name: orderly-web
-    tag: master 
+    tag: mrc-3916
     migrate: orderlyweb-migrate
     admin: orderly-web-user-cli
   url: https://localhost

--- a/inst/config/orderly-web.yml
+++ b/inst/config/orderly-web.yml
@@ -30,7 +30,7 @@ web:
   image:
     repo: vimc
     name: orderly-web
-    tag: mrc-3916
+    tag: master
     migrate: orderlyweb-migrate
     admin: orderly-web-user-cli
   url: https://localhost

--- a/man/orderlyweb_api_client.Rd
+++ b/man/orderlyweb_api_client.Rd
@@ -5,7 +5,7 @@
 \title{Create a low-level OrderlyWeb client}
 \usage{
 orderlyweb_api_client(host, port, token, name = NULL, https = TRUE,
-  prefix = NULL, api_version = 1, insecure = FALSE,
+  prefix = NULL, api_version = 2, insecure = FALSE,
   verbose = FALSE)
 }
 \arguments{
@@ -34,7 +34,7 @@ settings or credentials will be sent in the clear!}
 path within some larger website.}
 
 \item{api_version}{The API version to request - this should be
-left as 1.}
+left as 2.}
 
 \item{insecure}{Avoid SSL certificate testing - this is completely
 insecure (as bad as http) and exists only for testing.}

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -48,17 +48,17 @@ test_that("API client URL can use prefix, stripping slashes", {
   expect_equal(
     orderlyweb_api_client_url("host", 443, TRUE, "prefix", 1),
     list(www = "https://host:443/prefix",
-         api = "https://host:443/prefix/api/v1"))
+         api = "https://host:443/prefix/api/v2"))
   expect_equal(
     orderlyweb_api_client_url("host", 443, TRUE, "/prefix/", 1),
     list(www = "https://host:443/prefix",
-         api = "https://host:443/prefix/api/v1"))
+         api = "https://host:443/prefix/api/v2"))
 })
 
 
 test_that("API client URL ignores empty prefix", {
   cmp <- list(www = "https://host:443",
-              api = "https://host:443/api/v1")
+              api = "https://host:443/api/v2")
   expect_equal(
     orderlyweb_api_client_url("host", 443, TRUE, "", 1), cmp)
   expect_equal(

--- a/tests/testthat/test-client.R
+++ b/tests/testthat/test-client.R
@@ -48,17 +48,17 @@ test_that("API client URL can use prefix, stripping slashes", {
   expect_equal(
     orderlyweb_api_client_url("host", 443, TRUE, "prefix", 1),
     list(www = "https://host:443/prefix",
-         api = "https://host:443/prefix/api/v2"))
+         api = "https://host:443/prefix/api/v1"))
   expect_equal(
     orderlyweb_api_client_url("host", 443, TRUE, "/prefix/", 1),
     list(www = "https://host:443/prefix",
-         api = "https://host:443/prefix/api/v2"))
+         api = "https://host:443/prefix/api/v1"))
 })
 
 
 test_that("API client URL ignores empty prefix", {
   cmp <- list(www = "https://host:443",
-              api = "https://host:443/api/v2")
+              api = "https://host:443/api/v1")
   expect_equal(
     orderlyweb_api_client_url("host", 443, TRUE, "", 1), cmp)
   expect_equal(


### PR DESCRIPTION
Updates to match the updated error format and url prefix for OW API as per https://github.com/vimc/orderly-web/pull/506
Should not be merged til that is. Will then have to think about deployment - everyone using this package will need to update it once all instances are updated. How many is that? I can deploy VIMC ones, but no idea about others. We should chat about best way to roll this out since it's a breaking change...