### PR TITLE
Rename to use orderly1

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up orderly-web
         run: |
           pip3 install constellation
-          pip3 install orderly-web
+          pip3 install git+https://github.com/vimc/orderly-web-deploy.git
           orderly-web start --pull inst/config
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,7 @@ jobs:
           python-version: 3.11
 
       - name: Set up orderly-web
-        if: runner.os != 'Windows'
+        if: runner.os == 'Linux'
         run: |
           pip3 install constellation
           pip3 install git+https://github.com/vimc/orderly-web-deploy.git

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,6 +46,7 @@ jobs:
           python-version: 3.11
 
       - name: Set up orderly-web
+        if: runner.os != 'Windows'
         run: |
           pip3 install constellation
           pip3 install git+https://github.com/vimc/orderly-web-deploy.git

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,16 +1,13 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -22,26 +19,31 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: macos-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      ORDERLYWEB_TEST_TOKEN: ${{ secrets.ORDERLYWEB_TEST_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - name: Set up orderly-web
         run: |
@@ -49,46 +51,12 @@ jobs:
           pip3 install orderly-web
           orderly-web start --pull inst/config
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,52 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
 
-name: pkgdown
+name: pkgdown.yaml
+
+permissions: read-all
 
 jobs:
   pkgdown:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          use-public-rspm: true
 
-      - name: Install libs
-        run: |
-          brew install libgit2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
 
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("pkgdown", type = "binary")
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Deploy package
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -28,7 +28,6 @@ jobs:
           python-version: 3.11
 
       - name: Set up orderly-web
-        if: runner.os != 'Windows'
         run: |
           pip3 install constellation
           pip3 install git+https://github.com/vimc/orderly-web-deploy.git

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up orderly-web
         run: |
           pip3 install constellation
-          pip3 install orderly-web
+          pip3 install git+https://github.com/vimc/orderly-web-deploy.git
           orderly-web start --pull inst/config
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -28,6 +28,7 @@ jobs:
           python-version: 3.11
 
       - name: Set up orderly-web
+        if: runner.os != 'Windows'
         run: |
           pip3 install constellation
           pip3 install git+https://github.com/vimc/orderly-web-deploy.git

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,30 +1,31 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      ORDERLYWEB_TEST_TOKEN: ${{ secrets.ORDERLYWEB_TEST_TOKEN }}
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
-          python-version: 3.7
+          use-public-rspm: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
 
       - name: Set up orderly-web
         run: |
@@ -32,37 +33,41 @@ jobs:
           pip3 install orderly-web
           orderly-web start --pull inst/config
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-
-      - name: Install dependencies
-        run: |
-          install.packages(c("remotes"))
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("covr")
-        shell: Rscript {0}
+          extra-packages: any::covr, any::xml2
+          needs: coverage
 
       - name: Test coverage
-        run: covr::codecov()
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R:
              email = "rich.fitzjohn@gmail.com"),
       person("Imperial College of Science, Technology and Medicine",
              role = "cph"))
-Description: Client for 'OrderlyWeb' for use from the 'orderly'
+Description: Client for 'OrderlyWeb' for use from the 'orderly1'
     package.  Allows downloading of reports, running remote reports
     and other interaction with the remote report repository.
 Imports:
@@ -16,7 +16,7 @@ Imports:
     gert,
     httr,
     jsonlite,
-    orderly (>= 1.2.19),
+    orderly1 (>= 1.2.19),
     progress,
     zip
 Suggests:
@@ -29,4 +29,4 @@ BugReports: https://github.com/vimc/orderlyweb/issues
 Encoding: UTF-8
 LazyData: true
 Remotes:
-    vimc/orderly
+    vimc/orderly1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderlyweb
 Title: Orderly Support for 'OrderlyWeb'
-Version: 0.1.15
+Version: 0.1.16
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <!-- badges: start -->
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-[![R build status](https://github.com/vimc/orderlyweb/workflows/R-CMD-check/badge.svg)](https://github.com/vimc/orderlyweb/actions)
-[![codecov.io](https://codecov.io/github/vimc/orderlyweb/coverage.svg?branch=master)](https://codecov.io/github/vimc/orderlyweb?branch=master)
+[![R-CMD-check](https://github.com/vimc/orderlyweb/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/vimc/orderlyweb/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/vimc/orderlyweb/graph/badge.svg)](https://app.codecov.io/gh/vimc/orderlyweb)
 <!-- badges: end -->
 
 > R client support for OrderlyWeb

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > R client support for OrderlyWeb
 
-The R package [`orderly`](https://github.com/vimc/orderly) has a [web interface called OrderlyWeb](https://github.com/vimc/orderly-web); this package provides support for `orderly` to interact with `OrderlyWeb` in order to download reports from a remote server and run them remotely
+The R package [`orderly1`](https://github.com/vimc/orderly1) has a [web interface called OrderlyWeb](https://github.com/vimc/orderly-web); this package provides support for `orderly1` to interact with `OrderlyWeb` in order to download reports from a remote server and run them remotely
 
 ### Testing
 

--- a/scripts/demo.R
+++ b/scripts/demo.R
@@ -1,4 +1,4 @@
 path <- tempfile()
 dir.create(path)
 
-path <- orderly:::create_orderly_demo(quiet = TRUE)
+path <- orderly1:::create_orderly_demo(quiet = TRUE)

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -388,7 +388,7 @@ test_that("can pack a bundle", {
   expect_equal(dirname(res), tempdir())
   expect_match(basename(res), "^[0-9]{8}-[0-9]{6}-[[:xdigit:]]{8}\\.zip$")
 
-  ans <- orderly::orderly_bundle_run(res, echo = FALSE)
+  ans <- orderly1::orderly_bundle_run(res, echo = FALSE)
   expect_equal(ans$id, sub("\\.zip$", "", basename(res)))
   expect_false(ans$id %in% cl$report_versions("minimal"))
 

--- a/tests/testthat/test-orderly.R
+++ b/tests/testthat/test-orderly.R
@@ -7,7 +7,7 @@ test_that("create", {
   remote <- orderlyweb_remote(host = "localhost", port = 8888,
                               token = token, https = FALSE, name = "remote")
   expect_is(remote, "orderlyweb_remote")
-  expect_true(orderly:::implements_remote(remote))
+  expect_true(orderly1:::implements_remote(remote))
   expect_equal(remote$name, "remote")
 })
 
@@ -61,17 +61,17 @@ test_that("pull", {
   token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
   remote <- orderlyweb_remote(host = "localhost", port = 8888,
                               token = token, https = FALSE)
-  dest <- orderly::orderly_example("demo")
+  dest <- orderly1::orderly_example("demo")
   v <- max(remote$list_versions("minimal"))
 
   ## Directly pull and see the report:
   path <- remote$pull("minimal", v, FALSE)
   expect_true("orderly_run.rds" %in% dir(path))
-  expect_equal(nrow(orderly::orderly_list_archive(root = dest)), 0)
+  expect_equal(nrow(orderly1::orderly_list_archive(root = dest)), 0)
 
   ## Pull into the archive
-  orderly::orderly_pull_archive("minimal", v, dest, remote = remote)
-  res <- orderly::orderly_list_archive(root = dest)
+  orderly1::orderly_pull_archive("minimal", v, dest, remote = remote)
+  res <- orderly1::orderly_list_archive(root = dest)
   expect_equal(res, data_frame(name = "minimal", id = v))
 })
 
@@ -81,7 +81,7 @@ test_that("metadata", {
   token <- Sys.getenv("ORDERLYWEB_TEST_TOKEN")
   remote <- orderlyweb_remote(host = "localhost", port = 8888,
                               token = token, https = FALSE)
-  dest <- orderly::orderly_example("demo")
+  dest <- orderly1::orderly_example("demo")
   v <- max(remote$list_versions("minimal"))
 
   path <- remote$pull("minimal", v, FALSE)
@@ -151,7 +151,7 @@ test_that("bundle interface", {
                               token = token, https = FALSE)
 
   res <- remote$bundle_pack("minimal", progress = FALSE)
-  ans <- orderly::orderly_bundle_run(res, echo = FALSE)
+  ans <- orderly1::orderly_bundle_run(res, echo = FALSE)
   expect_true(remote$bundle_import(ans$path, progress = FALSE))
   expect_true(ans$id %in% remote$list_versions("minimal"))
 })
@@ -164,10 +164,10 @@ test_that("bundle high level interface", {
                               token = token, https = FALSE)
 
   capture.output(
-    res <- orderly::orderly_bundle_pack_remote("minimal", remote = remote))
-  ans <- orderly::orderly_bundle_run(res, echo = FALSE)
+    res <- orderly1::orderly_bundle_pack_remote("minimal", remote = remote))
+  ans <- orderly1::orderly_bundle_run(res, echo = FALSE)
   capture.output(
-    res <- orderly::orderly_bundle_import_remote(ans$path, remote = remote))
+    res <- orderly1::orderly_bundle_import_remote(ans$path, remote = remote))
 
   expect_true(ans$id %in% remote$list_versions("minimal"))
 })

--- a/tests/testthat/test-tools.R
+++ b/tests/testthat/test-tools.R
@@ -2,9 +2,9 @@ context("tools")
 
 test_that("unpack archive", {
   testthat::skip_on_cran()
-  path <- orderly::orderly_example("minimal")
-  id <- orderly::orderly_run("example", root = path, echo = FALSE)
-  p <- orderly::orderly_commit(id, root = path)
+  path <- orderly1::orderly_example("minimal")
+  id <- orderly1::orderly_run("example", root = path, echo = FALSE)
+  p <- orderly1::orderly_commit(id, root = path)
 
   zip <- zip_dir(p)
 
@@ -43,7 +43,7 @@ test_that("unpack failure: not an orderly archive", {
 
 test_that("unpack failure: not expected id", {
   testthat::skip_on_cran()
-  id <- orderly:::new_report_id()
+  id <- orderly1:::new_report_id()
   tmp <- file.path(tempfile(), id)
   dir.create(tmp, FALSE, TRUE)
   dir.create(file.path(tmp, "orderly.yml"))
@@ -56,7 +56,7 @@ test_that("unpack failure: not expected id", {
 
 test_that("unpack failure: missing files", {
   testthat::skip_on_cran()
-  id <- orderly:::new_report_id()
+  id <- orderly1:::new_report_id()
   tmp <- file.path(tempfile(), id)
   dir.create(tmp, FALSE, TRUE)
   dir.create(file.path(tmp, "orderly.yml"))


### PR DESCRIPTION
This PR updates the github actions for the orderlyweb client (which were ancient) and updates everything to use dependencies for orderly1 now that we have renamed that package. This will allow builds to generally continue so we can safely retire everything but leave old copies available on the vimc universe